### PR TITLE
fix: jest exits after tests run

### DIFF
--- a/api/context.ts
+++ b/api/context.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client'
+import { db } from './db'
 
 export interface Context {
   db: PrismaClient
@@ -6,6 +7,6 @@ export interface Context {
 
 export function createContext(): Context {
   return {
-    db: new PrismaClient(),
+    db,
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev": "ts-node-dev --transpile-only --no-notify api/app",
     "build": "tsc",
     "generate": "ts-node --transpile-only api/schema",
-    "test": "npm run generate && jest --forceExit"
+    "test": "npm run generate && jest"
   },
   "jest": {
     "preset": "ts-jest",

--- a/tests/__helpers.ts
+++ b/tests/__helpers.ts
@@ -6,6 +6,7 @@ import { GraphQLClient } from 'graphql-request'
 import { nanoid } from 'nanoid'
 import { join } from 'path'
 import { Client } from 'pg'
+import { db } from '../api/db'
 import { server } from '../api/server'
 
 type TestContext = {
@@ -42,7 +43,11 @@ function graphqlTestContext() {
   return {
     async before() {
       const port = await getPort({ port: makeRange(4000, 6000) })
+
       serverInstance = await server.listen({ port })
+      serverInstance.server.on('close', async () => {
+        await db.$disconnect()
+      })
 
       return new GraphQLClient(`http://localhost:${port}`)
     },


### PR DESCRIPTION
- Use the Prisma Client created in `db.ts` in the API Context
- Disconnect Prisma Client after running each test, allowing Jest to exit. Previously this was an issue as the Prisma Client connection was never closed and prevent Jest from exiting. This issue was fixed yesterday in [`a9ca189`
](https://github.com/graphql-nexus/tutorial/commit/8bcbe015fa1779770caa6b9dbcce67d000ba5c9c) using a workaround by passing the `--forceExit` flag to Jest.

This PR adds a proper fix for graphql-nexus/schema#678.