### PR TITLE
improve: use js object to store context

### DIFF
--- a/api/context.ts
+++ b/api/context.ts
@@ -5,8 +5,6 @@ export interface Context {
   db: PrismaClient
 }
 
-export function createContext(): Context {
-  return {
-    db,
-  }
+export const context = {
+  db,
 }


### PR DESCRIPTION
- Use JS object to store the context instead of a function

Update changes made in graphql-nexus/schema#718